### PR TITLE
Added support for managing VLAN interfaces on Debian derivatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,40 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP. Don't configure, let the network_interface role configure
+  config.vm.network "private_network", ip: "192.168.33.10", auto_config: false
+
+  # Make sure VLAN tagging works on VirtualBox VMs
+  config.vm.provider "virtualbox" do |vb|
+    # Set the private network nic to be AMD PCI, not Intel, so that VLAN
+    # tagging works (eth1, eth0 is reserved for Vagrant work, don't tweak)
+    # VBoxManage modifyvm $box --nictype1 virtio
+#    vb.customize = ["modifyvm", :id, "--nictype2", "virtio"]
+
+    # Customize the amount of memory on the VM:
+    vb.memory = "1024"
+  end
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "vagrant-playbook.yml"
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ../

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,6 @@
   environment: env
   when: ansible_os_family == 'Debian'
 
-
 - name: Make sure the include line is there in interfaces file
   lineinfile: >
      regexp="^source\ \/etc\/network\/interfaces.d\/\*"
@@ -28,14 +27,20 @@
   file: path=/etc/network/interfaces.d  state=directory
   when: ansible_os_family == "Debian"
 
-- name: Create the network configuration file for ethernet devices
+- name: Create the network configuration file for ethernet devices (RedHat)
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_ether_interfaces
-  when: network_ether_interfaces is defined
+  when: network_ether_interfaces is defined and ansible_os_family == 'RedHat'
+  register: ether_result
+
+- name: Create the network configuration file for ethernet devices (Debian)
+  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/{{ item.device }}.cfg
+  with_items: network_ether_interfaces
+  when: network_ether_interfaces is defined and ansible_os_family == 'Debian'
   register: ether_result
 
 - name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: network_ether_interfaces
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
@@ -54,7 +59,7 @@
   when: bond_result|changed
 
 - name: Write configuration files for route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: network_bond_interfaces
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
@@ -64,7 +69,7 @@
 
 - name: Create the network configuration file for slave in the bond devices
   template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
-  with_subelements: 
+  with_subelements:
    - network_bond_interfaces
    - bond_slaves
   when: network_bond_interfaces is defined
@@ -78,16 +83,26 @@
   with_items: bond_result.results
   when: bond_result is defined and item.changed and ansible_os_family == 'RedHat'
 
-- name: Create the network configuration file for vlan devices
+- name: Create the network configuration file for vlan devices (Debian)
+  template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/{{ item.device }}.cfg
+  with_items: network_vlan_interfaces
+  when: network_vlan_interfaces is defined and ansible_os_family == 'Debian'
+  register: vlan_result
+
+- name: Create the network configuration file for vlan devices (RedHat)
   template: src=ethernet_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.device }}
   with_items: network_vlan_interfaces
-  when: network_vlan_interfaces is defined
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat'
   register: vlan_result
 
 - name: Write configuration files for rhel route configuration with vlan
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: network_vlan_interfaces
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
+
+- name: Make sure the vlan/802.1q module is loaded
+  modprobe: name=8021q state=present
+  when: vlan_result|changed and ansible_os_family == 'Debian'
 
 - shell: ifdown {{ item.item.device }}; ifup {{ item.item.device }}
   with_items: vlan_result.results

--- a/vagrant-playbook.yml
+++ b/vagrant-playbook.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  user: vagrant
+  sudo: True
+  roles:
+    - role: network_interface
+      network_ether_interfaces:
+        - device: eth1
+          bootproto: static
+          address: 192.168.33.10
+          netmask: 255.255.255.0
+          gateway: 192.168.33.1
+      network_vlan_interfaces:
+        - device: eth1.2
+          bootproto: static
+          address: 192.168.20.18
+          netmask: 255.255.255.0

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,5 +4,6 @@ network_pkgs:
   - python-selinux
   - bridge-utils
   - ifenslave-2.6
+  - vlan
 
 net_path: "/etc/network/interfaces.d"


### PR DESCRIPTION
- Configure VLAN's on Debian based systems
- Renamed /etc/network/interfaces.d/foo to match Debian style
- Added Vagrantfile, ansible.cfg & vagrant-playbook.yml to support
  easy development of this role
